### PR TITLE
Added warning message

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,7 +98,12 @@ def LoadAllowedWords():
             AllowedWords.append(Word.strip().upper())
         WordsFile.close()
     except:
-        pass
+        print("###########################################")
+        print("MISSING DICTIONARY FILE 'chilwellwords.txt'")
+        print("-------------------------------------------")
+        print("The game will not function properly without")
+        print("It is recommend that you replace this file")
+        print("###########################################")
     return AllowedWords
 
 


### PR DESCRIPTION
When initially loading the dictionary file, if it is found missing a warning symbol is displayed. The game can be played without, but all submitted words will be found the be invalid.